### PR TITLE
Attach fixes

### DIFF
--- a/ev3sim/attach.py
+++ b/ev3sim/attach.py
@@ -155,8 +155,8 @@ def main():
             @mock.patch('ev3dev2.motor.Motor.wait', wait)
             @mock.patch('ev3dev2.Device.__init__', device__init__)
             @mock.patch('ev3dev2.Device._attribute_file_open', _attribute_file_open)
-            @mock.patch('code_helpers.is_ev3', False)
-            @mock.patch('code_helpers.is_sim', True)
+            @mock.patch('ev3sim.code_helpers.is_ev3', False)
+            @mock.patch('ev3sim.code_helpers.is_sim', True)
             def run_script(fname):
                 from importlib.machinery import SourceFileLoader
                 module = SourceFileLoader('__main__', fname).load_module()
@@ -191,9 +191,10 @@ def main():
     result_bucket = Queue(maxsize=1)
 
     from threading import Thread
+    from ev3sim.file_helper import find_abs
 
     comm_thread = Thread(target=comms, args=(shared_data, result_bucket,), daemon=True)
-    robot_thread = Thread(target=robot, args=(args.filename, shared_data, result_bucket,), daemon=True)
+    robot_thread = Thread(target=robot, args=(find_abs(args.filename, allowed_areas=['local', 'local/robots/', 'package', 'package/robots/']), shared_data, result_bucket,), daemon=True)
     write_thread = Thread(target=write, args=(shared_data, result_bucket,), daemon=True)
 
     comm_thread.start()

--- a/ev3sim/file_helper.py
+++ b/ev3sim/file_helper.py
@@ -40,7 +40,7 @@ def find_abs(filepath, allowed_areas=None):
         elif area == 'local':
             path = filepath
         elif area.startswith('local'):
-            path = os.path.join(ROOT, area[6:], *fnames)
+            path = os.path.join(area[6:], *fnames)
         else:
             raise ValueError(f'Unknown file area {area}')
         if os.path.isdir(path) or os.path.isfile(path):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(os.path.join(HERE, "requirements.txt")) as fid:
 
 setup(
     name="ev3sim",
-    version="1.0.8",
+    version="1.0.9",
     description="Simulate ev3dev programs in Python",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Some of these errors crept in when I moved everything into the `ev3` folder - I forgot to check the `attach` script.

This also ensures that the file helper will correctly look into relative locations when specified.