### PR TITLE
Use correct slash on Manifest file.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 global-include *.yaml
 global-include *.png
 global-include *.py
-graft ev3sim\assets
+graft ev3sim/assets


### PR DESCRIPTION
Use the correct form of slash to separate directories in line with https://packaging.python.org/guides/using-manifest-in/.

Thanks @platy11 for bringing this to attention!