### PR TITLE
Bind only to localhost by default

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020 the Melbourne High School ev3sim authors
+Copyright 2020 Melbourne High School and contributors
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020 Melbourne High School
+Copyright 2020 the Melbourne High School ev3sim authors
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/ev3sim/sim.py
+++ b/ev3sim/sim.py
@@ -7,6 +7,7 @@ parser = argparse.ArgumentParser(description='Run the simulation, include some r
 parser.add_argument('--preset', '-p', type=str, help="Path of preset file to load. (You shouldn't need to change this, by default it is presets/soccer.yaml)", default='soccer.yaml', dest='preset')
 parser.add_argument('robots', nargs='+', help='Path of robots to load. Separate each robot path by a space.')
 parser.add_argument('--batch', '-b', action='store_true', help='Whether to use a batched command to run this simulation.', dest='batched')
+parser.add_argument('--bind_addr', default='[::1]:50051', metavar='address:port', help="The IP address and port to run on (you shouldn't need to change this). Default is [::1]:50051 (localhost only). Use [::]:50051 to listen on all network interfaces.")
 
 def main(passed_args = None):
     if passed_args is None:
@@ -17,10 +18,10 @@ def main(passed_args = None):
     if args.batched:
         from ev3sim.batched_run import batched_run
         assert len(args.robots) == 1, "Exactly one batched command file should be provided."
-        batched_run(args.robots[0])
+        batched_run(args.robots[0], args.bind_addr)
     else:
         from ev3sim.single_run import single_run
-        single_run(args.preset, args.robots)
+        single_run(args.preset, args.robots, args.bind_addr)
 
 if __name__ == '__main__':
     main()

--- a/ev3sim/simulation/communication.py
+++ b/ev3sim/simulation/communication.py
@@ -19,10 +19,9 @@ from ev3sim.simulation.loader import ScriptLoader
 TICK_WAITING_TIMEOUT = 0.03
 SIM_DIED_TIME = 0.3
 
-def start_server_with_shared_data(data, result):
+def start_server_with_shared_data(data, result, bind_addr):
     try:
         class SimulationDealer(ev3sim.simulation.comm_schema_pb2_grpc.SimulationDealerServicer):
-
             def RequestTickUpdates(self, request, context):
                 rob_id = request.robot_id
                 if rob_id not in data['active_count']:
@@ -236,7 +235,7 @@ def start_server_with_shared_data(data, result):
         def serve():
             server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
             ev3sim.simulation.comm_schema_pb2_grpc.add_SimulationDealerServicer_to_server(SimulationDealer(), server)
-            server.add_insecure_port('[::]:50051')
+            server.add_insecure_port(bind_addr)
             server.start()
             server.wait_for_termination()
 

--- a/ev3sim/single_run.py
+++ b/ev3sim/single_run.py
@@ -7,8 +7,7 @@ from ev3sim.file_helper import find_abs
 import yaml
 from ev3sim.simulation.loader import runFromConfig
 
-def single_run(preset_filename, robots):
-
+def single_run(preset_filename, robots, bind_addr):
     preset_file = find_abs(preset_filename, allowed_areas=['local', 'local/presets/', 'package', 'package/presets/'])
     with open(preset_file, 'r') as f:
         config = yaml.safe_load(f)
@@ -38,7 +37,7 @@ def single_run(preset_filename, robots):
             return
         result.put(True)
 
-    comm_thread = Thread(target=start_server_with_shared_data, args=(shared_data, result_bucket), daemon=True)
+    comm_thread = Thread(target=start_server_with_shared_data, args=(shared_data, result_bucket, bind_addr), daemon=True)
     sim_thread = Thread(target=run, args=(shared_data, result_bucket), daemon=True)
 
     comm_thread.start()


### PR DESCRIPTION
This PR:
- sets `ev3sim` to only bind to localhost (::1) by default
- adds flags (`--simulator_addr` for `ev3attach` and `--bind_addr` for `ev3sim`) to allow users to listen on all interfaces or use a different port if they want to for whatever reason

Note that this PR targets main, but was based on batched_commands so should be merged after #53. 
I haven't tested this on Windows yet, presumably it works but it would be best to check.