### PR TITLE
Fix setup.py to allow for emoji in the README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ REQUIRES_PYTHON = '>=3.7.0'
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(HERE, "README.md")) as fid:
+with open(os.path.join(HERE, "README.md"), encoding='utf-8') as fid:
     README = fid.read()
 
 with open(os.path.join(HERE, "requirements.txt")) as fid:


### PR DESCRIPTION
pip installing currently fails on `main` because of the emojis added by all-contributors yesterday.