### PR TITLE
Add option to mock specific values in presets.

### DIFF
--- a/ev3sim/single_run.py
+++ b/ev3sim/single_run.py
@@ -40,11 +40,13 @@ def single_run(preset_filename, robots, bind_addr):
         result.put(True)
 
     # Handle any other settings modified by the preset.
-    settings = config.get('settings', {})
+    settings = config.get("settings", {})
     for keyword, value in settings.items():
         run = mock.patch(keyword, value)(run)
 
-    comm_thread = Thread(target=start_server_with_shared_data, args=(shared_data, result_bucket, bind_addr), daemon=True)
+    comm_thread = Thread(
+        target=start_server_with_shared_data, args=(shared_data, result_bucket, bind_addr), daemon=True
+    )
     sim_thread = Thread(target=run, args=(shared_data, result_bucket), daemon=True)
 
     comm_thread.start()

--- a/ev3sim/single_run.py
+++ b/ev3sim/single_run.py
@@ -5,6 +5,7 @@ from queue import Queue
 import time
 from ev3sim.file_helper import find_abs
 import yaml
+from unittest import mock
 from ev3sim.simulation.loader import runFromConfig
 
 def single_run(preset_filename, robots, bind_addr):
@@ -36,6 +37,11 @@ def single_run(preset_filename, robots, bind_addr):
             result.put(('Simulation', e))
             return
         result.put(True)
+
+    # Handle any other settings modified by the preset.
+    settings = config.get('settings', {})
+    for keyword, value in settings.items():
+        run = mock.patch(keyword, value)(run)
 
     comm_thread = Thread(target=start_server_with_shared_data, args=(shared_data, result_bucket, bind_addr), daemon=True)
     sim_thread = Thread(target=run, args=(shared_data, result_bucket), daemon=True)


### PR DESCRIPTION
Allows for presets to change class constants and other things with mocking.

To test, try adding the following to `ev3sim/presets/soccer.yaml`:
```
settings:
  ev3sim.presets.soccer.SoccerInteractor.GOAL_SCORE_PAUSE_DELAY: 10
```

This will make the delay after soccer goals are scored be 10.

This is the change that will allow specific randomisation constants to be changed via preset @peter-drew, and also after merging this I'll probably remove the command line flag for turning on/off randomisation, we'll instead have to presets, soccer (default) and soccer_randomised.