### PR TITLE
Separate lint and test workflows.

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -11,16 +11,13 @@ jobs:
   test-package:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.x]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.x
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -1,7 +1,7 @@
-# This workflow will install Python dependencies, and run tests.
+# This workflow will install Python dependencies, lint with black.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python test suite
+name: Python linting
 
 on:
   push:
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.x]
+        python-version: [3.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,6 +28,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Test with pytest
+    - name: Lint with black
       run: |
-        pytest
+        black --config pyproject.toml . --check


### PR DESCRIPTION
Resolves  #118 .

@peter-drew I've made it so the linting only uses python 3.x. I think this is better because I don't really see any reason to lint with a lower version, in fact that could cause some problems down the line (If linting for 3.7 goes one way but for 3.x goes another way, due to some change in style)