### PR TITLE
Add a print lock and flush stdout in communications thread.

### DIFF
--- a/ev3sim/simulation/communication.py
+++ b/ev3sim/simulation/communication.py
@@ -6,6 +6,7 @@ from concurrent import futures
 import logging
 
 import grpc
+import sys
 
 import ev3sim.simulation.comm_schema_pb2
 import ev3sim.simulation.comm_schema_pb2_grpc
@@ -22,6 +23,8 @@ SIM_DIED_TIME = 0.3
 
 def start_server_with_shared_data(data, result, bind_addr):
     try:
+
+        print_lock = threading.Lock()
 
         class SimulationDealer(ev3sim.simulation.comm_schema_pb2_grpc.SimulationDealerServicer):
             def RequestTickUpdates(self, request, context):
@@ -65,7 +68,9 @@ def start_server_with_shared_data(data, result, bind_addr):
                     message = []
                     for i, line in enumerate(lines):
                         message.append(f"{tag}{line}" if line and i != len(lines) - 1 else line)
-                    print(*message, sep="\n", end="")
+                    with print_lock:
+                        print(*message, sep="\n", end="")
+                        sys.stdout.flush()
                 return ev3sim.simulation.comm_schema_pb2.RobotLogResult(result=True)
 
             def RequestServer(self, request, context):

--- a/ev3sim/simulation/communication.py
+++ b/ev3sim/simulation/communication.py
@@ -6,7 +6,6 @@ from concurrent import futures
 import logging
 
 import grpc
-import sys
 
 import ev3sim.simulation.comm_schema_pb2
 import ev3sim.simulation.comm_schema_pb2_grpc
@@ -69,8 +68,7 @@ def start_server_with_shared_data(data, result, bind_addr):
                     for i, line in enumerate(lines):
                         message.append(f"{tag}{line}" if line and i != len(lines) - 1 else line)
                     with print_lock:
-                        print(*message, sep="\n", end="")
-                        sys.stdout.flush()
+                        print(*message, sep="\n", end="", flush=True)
                 return ev3sim.simulation.comm_schema_pb2.RobotLogResult(result=True)
 
             def RequestServer(self, request, context):


### PR DESCRIPTION
Currently prints can interrupt eachother, which looks ugly.

This change ensures each print is handled separately, and stdout is flushed before a new print is started.