### PR TITLE
Modify out on white collider for bots.

### DIFF
--- a/ev3sim/presets/soccer.yaml
+++ b/ev3sim/presets/soccer.yaml
@@ -434,8 +434,8 @@ elements:
   static: true
   visual:
     name: Rectangle
-    width: 182
-    height: 126
+    width: 192
+    height: 136
     fill: null
     stroke_width: 0
     zPos: 5.2


### PR DESCRIPTION
Extends the collider which generates the out on white ruling when the bot leaves. You can visualise this change by making the `fill` of `centreField` object to '#ff0000' in `soccer.yaml`.