### PR TITLE
Dialog fix

### DIFF
--- a/ev3sim/visual/menus/base_menu.py
+++ b/ev3sim/visual/menus/base_menu.py
@@ -84,8 +84,8 @@ class BaseMenu(pygame_gui.UIManager):
         self.window_mode = self.WINDOW_MODE_NORMAL
         self.regenerateObjects()
 
-    def handleEvent(self, event):
+    def handleEvent(self, event, button_filter=lambda x: True):
         if event.type == pygame.USEREVENT and event.user_type == pygame_gui.UI_BUTTON_PRESSED:
             for id, method, args, kwargs in self._button_events:
-                if event.ui_object_id.split(".")[-1] == id:
+                if event.ui_object_id.split(".")[-1] == id and button_filter(id):
                     method(*args, **kwargs)

--- a/ev3sim/visual/menus/bot_edit.py
+++ b/ev3sim/visual/menus/bot_edit.py
@@ -674,7 +674,11 @@ class BotEditMenu(BaseMenu):
             self.onSave(self.bot_dir_file[1])
 
     def handleEvent(self, event):
-        super().handleEvent(event)
+        if self.mode == self.MODE_NORMAL:
+            button_filter = lambda x: True
+        else:
+            button_filter = lambda x: False
+        super().handleEvent(event, button_filter=button_filter)
         if self.mode == self.MODE_NORMAL:
             if event.type == pygame.MOUSEMOTION:
                 self.actual_mpos = event.pos

--- a/ev3sim/visual/menus/rescue_edit.py
+++ b/ev3sim/visual/menus/rescue_edit.py
@@ -698,7 +698,11 @@ class RescueMapEditMenu(BaseMenu):
         self.previous_info["settings"]["rescue"]["BOT_SPAWN_POSITION"][0][0] = pos
 
     def handleEvent(self, event):
-        super().handleEvent(event)
+        if self.mode == self.MODE_NORMAL or self.mode == self.MODE_CAN_DRAGGING:
+            button_filter = lambda x: True
+        else:
+            button_filter = lambda x: False
+        super().handleEvent(event, button_filter=button_filter)
         if self.mode == self.MODE_NORMAL:
             if event.type == pygame.MOUSEMOTION:
                 self.current_mpos = event.pos


### PR DESCRIPTION
Fixes #205 . Just makes it so that other buttons (Such as Save/Cancel) can't be interacted with when a dialog is opened, which will likely mitigate many of the bugs encountered so far.

Has been tested locally, everything seems to work as intended.