### PR TITLE
Use pygame_gui filepicker dialog rather than tkinter for mac support.

### DIFF
--- a/ev3sim/visual/menus/workspace_menu.py
+++ b/ev3sim/visual/menus/workspace_menu.py
@@ -59,24 +59,28 @@ In order to use ev3sim, you need to specify a <font color="#06d6a0">workspace fo
     def clickSelect(self):
         # Open file dialog.
         import yaml
-        from tkinter import Tk
-        from tkinter.filedialog import askdirectory
         from ev3sim.simulation.loader import StateHandler
         from ev3sim.visual.manager import ScreenObjectManager
 
-        Tk().withdraw()
-        directory = askdirectory()
-        if not directory:
-            return
-        conf_file = find_abs("user_config.yaml", allowed_areas=config_locations())
-        with open(conf_file, "r") as f:
-            conf = yaml.safe_load(f)
-        conf["app"]["workspace_folder"] = directory
-        with open(conf_file, "w") as f:
-            f.write(yaml.dump(conf))
-        StateHandler.WORKSPACE_FOLDER = directory
-        ScreenObjectManager.instance.popScreen()
-        ScreenObjectManager.instance.pushScreen(ScreenObjectManager.SCREEN_MENU)
+        def onComplete(directory):
+            if not directory:
+                return
+            conf_file = find_abs("user_config.yaml", allowed_areas=config_locations())
+            with open(conf_file, "r") as f:
+                conf = yaml.safe_load(f)
+            conf["app"]["workspace_folder"] = directory
+            with open(conf_file, "w") as f:
+                f.write(yaml.dump(conf))
+            StateHandler.WORKSPACE_FOLDER = directory
+            ScreenObjectManager.instance.popScreen()
+            ScreenObjectManager.instance.pushScreen(ScreenObjectManager.SCREEN_MENU)
+
+        self.addFileDialog(
+            "Select Workspace",
+            None,
+            True,
+            onComplete,
+        )
 
     def onPop(self):
         pass

--- a/ev3sim/visual/settings/elements.py
+++ b/ev3sim/visual/settings/elements.py
@@ -142,25 +142,20 @@ class FileEntry(SettingsVisualElement):
 
     def handlePressed(self, idx):
         assert idx == 2, f"{idx} expected to be 2."
-        # Open file dialog.
-        from tkinter import Tk
-        from tkinter.filedialog import askdirectory, askopenfilename
 
-        Tk().withdraw()
-        if self.is_directory:
-            directory = askdirectory()
-            if not directory:
+        def onComplete(path):
+            if self.is_directory:
+                if not path:
+                    return
+                self.current = path
+                self.filename.set_text(self.current)
                 return
-            self.current = directory
-            self.filename.set_text(self.current)
-        else:
-            filename = askopenfilename().replace("/", "\\")
-            if not filename:
+            if not path:
                 return
             for pathname in self.relative_paths:
                 dirpath = find_abs_directory(pathname, create=True)
-                if filename.startswith(dirpath):
-                    actual_filename = filename[len(dirpath) :]
+                if path.startswith(dirpath):
+                    actual_path = path[len(dirpath) :]
                     break
             else:
                 msg = '<font color="#DD4045">This file must be contained in one of the following directories:</font>'
@@ -170,8 +165,15 @@ class FileEntry(SettingsVisualElement):
                 msg = msg + "</font>"
                 self.menu.addErrorDialog(msg)
                 return
-            self.current = actual_filename
+            self.current = actual_path
             self.filename.set_text(self.current)
+
+        self.menu.addFileDialog(
+            "Select " + self.title,
+            find_abs_directory(self.relative_paths[0], create=True) if self.relative_paths else None,
+            self.is_directory,
+            onComplete,
+        )
 
 
 class TextEntry(SettingsVisualElement):


### PR DESCRIPTION
Fixes #218

Is a bit clunkier but has been tested and works (and should also work on Mac, as Tk was the thing causing mac errors. Avoiding these file dialogs has ev3sim work fine on mac.