### PR TITLE
Revert to tkinter file dialog if on windows.

### DIFF
--- a/ev3sim/visual/menus/workspace_menu.py
+++ b/ev3sim/visual/menus/workspace_menu.py
@@ -75,12 +75,22 @@ In order to use ev3sim, you need to specify a <font color="#06d6a0">workspace fo
             ScreenObjectManager.instance.popScreen()
             ScreenObjectManager.instance.pushScreen(ScreenObjectManager.SCREEN_MENU)
 
-        self.addFileDialog(
-            "Select Workspace",
-            None,
-            True,
-            onComplete,
-        )
+        import platform
+
+        if platform.system() == "Windows":
+            from tkinter import Tk
+            from tkinter.filedialog import askdirectory
+
+            Tk().withdraw()
+            directory = askdirectory()
+            onComplete(directory)
+        else:
+            self.addFileDialog(
+                "Select Workspace",
+                None,
+                True,
+                onComplete,
+            )
 
     def onPop(self):
         pass

--- a/ev3sim/visual/settings/elements.py
+++ b/ev3sim/visual/settings/elements.py
@@ -170,12 +170,26 @@ class FileEntry(SettingsVisualElement):
             self.current = actual_path
             self.filename.set_text(self.current)
 
-        self.menu.addFileDialog(
-            "Select " + self.title,
-            find_abs_directory(self.relative_paths[0], create=True) if self.relative_paths else None,
-            self.is_directory,
-            onComplete,
-        )
+        import platform
+
+        if platform.system() == "Windows":
+            from os.path import join
+            from tkinter import Tk
+            from tkinter.filedialog import askdirectory, askopenfilename
+
+            Tk().withdraw()
+            if self.is_directory:
+                path = askdirectory()
+            else:
+                path = join(askopenfilename())
+            onComplete(path)
+        else:
+            self.menu.addFileDialog(
+                "Select " + self.title,
+                find_abs_directory(self.relative_paths[0], create=True) if self.relative_paths else None,
+                self.is_directory,
+                onComplete,
+            )
 
 
 class TextEntry(SettingsVisualElement):


### PR DESCRIPTION
Previously we just used the tkinter file dialog for file/directory selecting. Sadly this isn't supported by Mac, and so we had to add pygame_gui's file selector as part of #224 (This is because Mac pygame uses tkinter as the backend, where as windows uses SDL2).

The tkinter dialog is superior and less buggy however, so we should revert this change for windows clients.