### PR TITLE
Randomisation settings

### DIFF
--- a/ev3sim/assets/default_theme.json
+++ b/ev3sim/assets/default_theme.json
@@ -326,6 +326,16 @@
             "size": "24"
         }
     },
+    "settings-title": {
+        "colours": {
+            "normal_text": "#f7ede2",
+            "dark_bg": "#00000000"
+        },
+        "font": {
+            "name": "Roboto",
+            "size": "24"
+        }
+    },
     "checkbox-button": {
         "colours": {
             "normal_bg": "#ffffff00",

--- a/ev3sim/simulation/loader.py
+++ b/ev3sim/simulation/loader.py
@@ -328,11 +328,37 @@ class StateHandler:
             "FPS": ObjectSetting(ScriptLoader, "VISUAL_TICK_RATE"),
             "tick_rate": ObjectSetting(ScriptLoader, "GAME_TICK_RATE"),
             "timescale": ObjectSetting(ScriptLoader, "TIME_SCALE"),
+            "randomise_sensors": ObjectSetting(ScriptLoader, "RANDOMISE_SENSORS"),
             "console_log": ObjectSetting(Logger, "LOG_CONSOLE"),
             "workspace_folder": ObjectSetting(StateHandler, "WORKSPACE_FOLDER"),
         }
+        from ev3sim.devices.colour.base import ColourSensorMixin
+        from ev3sim.devices.colour.ev3 import ColorSensor
+        from ev3sim.devices.compass.ev3 import CompassSensor
+        from ev3sim.devices.infrared.base import InfraredSensorMixin
+        from ev3sim.devices.motor.base import MotorMixin
+        from ev3sim.devices.ultrasonic.base import UltrasonicSensorMixin
+
+        randomisation_settings = {
+            "COLOUR_SENSOR_RADIUS": ObjectSetting(ColourSensorMixin, "SENSOR_RADIUS"),
+            "COLOUR_SENSOR_SAMPLING_POINTS": ObjectSetting(ColourSensorMixin, "SENSOR_POINTS"),
+            "COLOUR_MAX_RGB_BIAS": ObjectSetting(ColorSensor, "MAX_RGB_BIAS"),
+            "COLOUR_MIN_RGB_BIAS": ObjectSetting(ColorSensor, "MIN_RGB_BIAS"),
+            "COMPASS_N_POINTS": ObjectSetting(CompassSensor, "NEAREST_POINTS_NUMBER"),
+            "COMPASS_POINT_VARIANCE": ObjectSetting(CompassSensor, "NEAREST_POINTS_VARIANCE"),
+            "COMPASS_NOISE_RATE": ObjectSetting(CompassSensor, "NOISE_WIDTH_PER_TICK"),
+            "COMPASS_NOISE_AMP": ObjectSetting(CompassSensor, "NOISE_AMPLIFIER"),
+            "COMPASS_MAXIMUM_NOISE_EFFECT": ObjectSetting(CompassSensor, "NOISE_EFFECT_MAX"),
+            "INFRARED_BIAS_AMP": ObjectSetting(InfraredSensorMixin, "SUBSENSOR_BIAS_MAGNITUDE"),
+            "MOTOR_MIN_MULT": ObjectSetting(MotorMixin, "MIN_FORCE_PCT"),
+            "MOTOR_MAX_MULT": ObjectSetting(MotorMixin, "MAX_FORCE_PCT"),
+            "MOTOR_N_SPEEDS": ObjectSetting(MotorMixin, "FIXED_SPEED_POINTS"),
+            "ULTRASONIC_NOISE_ANGLE_AMPLITUDE": ObjectSetting(UltrasonicSensorMixin, "ANGLE_RANDOM_AMPLITUDE"),
+            "ULTRASONIC_OFFSET_AMP": ObjectSetting(UltrasonicSensorMixin, "OFFSET_MAX"),
+        }
         settings.addSettingGroup("app", loader_settings)
         settings.addSettingGroup("screen", screen_settings)
+        settings.addSettingGroup("randomisation", randomisation_settings)
         self.shared_info = {}
 
     def closeProcesses(self):

--- a/ev3sim/visual/manager.py
+++ b/ev3sim/visual/manager.py
@@ -19,6 +19,7 @@ class ScreenObjectManager:
     SCREEN_SIM = "SIMULATOR"
     SCREEN_BOTS = "BOT_SELECT"
     SCREEN_SETTINGS = "SETTINGS"
+    SCREEN_RANDOM_SETTINGS = "RANDOM_SETTINGS"
     SCREEN_WORKSPACE = "WORKSPACE"
     SCREEN_UPDATE = "UPDATE"
     SCREEN_BOT_EDIT = "BOT_EDIT"
@@ -106,6 +107,7 @@ class ScreenObjectManager:
         from ev3sim.visual.settings.menu import SettingsMenu
 
         self.screens[self.SCREEN_SETTINGS] = SettingsMenu((self.SCREEN_WIDTH, self.SCREEN_HEIGHT))
+        self.screens[self.SCREEN_RANDOM_SETTINGS] = SettingsMenu((self.SCREEN_WIDTH, self.SCREEN_HEIGHT))
         # Rescue edit screen
         from ev3sim.visual.menus.rescue_edit import RescueMapEditMenu
 

--- a/ev3sim/visual/settings/elements.py
+++ b/ev3sim/visual/settings/elements.py
@@ -41,6 +41,37 @@ class SettingsVisualElement:
         raise NotImplementedError()
 
 
+class Title(SettingsVisualElement):
+
+    num_objs = 1
+
+    def __init__(self, title, offset):
+        self.title = title
+        self.offset = offset
+        self.menu = None
+        self.json_keys = "__filename__"
+
+    def getFromJson(self, json_obj):
+        pass
+
+    def setToJson(self, json_obj):
+        pass
+
+    def generateVisual(self, size, container, manager, idx):
+        self.container = container
+        off = self.offset(size)
+        label_size = ((size[0] - 40), 40)
+        label_pos = (off[0] + 20, off[1])
+        self.button = pygame_gui.elements.UILabel(
+            relative_rect=pygame.Rect(*label_pos, *label_size),
+            manager=manager,
+            object_id=pygame_gui.core.ObjectID(f"{idx}-title-label", "settings-title"),
+            container=container,
+            text=self.title,
+        )
+        return [self.button]
+
+
 class Button(SettingsVisualElement):
 
     num_objs = 1

--- a/ev3sim/visual/settings/main_settings.py
+++ b/ev3sim/visual/settings/main_settings.py
@@ -8,11 +8,11 @@ def onClickConfigEditor(filename):
     from ev3sim.visual.manager import ScreenObjectManager
 
     ScreenObjectManager.instance.pushScreen(
-        ScreenObjectManager.SCREEN_SETTINGS,
+        ScreenObjectManager.SCREEN_RANDOM_SETTINGS,
         file=find_abs("user_config.yaml", config_locations()),
         settings=randomisation_settings,
     )
-    ScreenObjectManager.instance.screens[ScreenObjectManager.SCREEN_SETTINGS].clearEvents()
+    ScreenObjectManager.instance.screens[ScreenObjectManager.SCREEN_RANDOM_SETTINGS].clearEvents()
 
 
 main_settings = [

--- a/ev3sim/visual/settings/main_settings.py
+++ b/ev3sim/visual/settings/main_settings.py
@@ -1,4 +1,19 @@
-from ev3sim.visual.settings.elements import NumberEntry, FileEntry, Checkbox
+from ev3sim.file_helper import find_abs
+from ev3sim.search_locations import config_locations
+from ev3sim.visual.settings.elements import NumberEntry, FileEntry, Checkbox, Button
+from ev3sim.visual.settings.randomisation_settings import randomisation_settings
+
+
+def onClickConfigEditor(filename):
+    from ev3sim.visual.manager import ScreenObjectManager
+
+    ScreenObjectManager.instance.pushScreen(
+        ScreenObjectManager.SCREEN_SETTINGS,
+        file=find_abs("user_config.yaml", config_locations()),
+        settings=randomisation_settings,
+    )
+    ScreenObjectManager.instance.screens[ScreenObjectManager.SCREEN_SETTINGS].clearEvents()
+
 
 main_settings = [
     {
@@ -14,6 +29,13 @@ main_settings = [
             ),
             NumberEntry(["app", "FPS"], 30, "FPS", (lambda s: (0, 120) if s[0] < 540 else (0, 70)), int),
             Checkbox(["app", "console_log"], True, "Console", (lambda s: (0, 170) if s[0] < 540 else (s[0] / 2, 70))),
+        ],
+    },
+    {
+        "height": (lambda s: 90),
+        "objects": [
+            Checkbox(["app", "randomise_sensors"], False, "Random Noise", (lambda s: (0, 20))),
+            Button("Randomisation Config", (lambda s: (0, 70) if s[0] < 540 else (s[0] / 2, 20)), onClickConfigEditor),
         ],
     },
     {

--- a/ev3sim/visual/settings/menu.py
+++ b/ev3sim/visual/settings/menu.py
@@ -23,7 +23,7 @@ class SettingsMenu(BaseMenu):
 
     def generateObjects(self):
         # Scrolling container
-        old_y = getattr(getattr(self, "scrolling_container", None), "cur_y", 0)
+        old_y = 0
         self.scrolling_container = CustomScroll(
             relative_rect=pygame.Rect(0, 0, *self._size),
             manager=self,

--- a/ev3sim/visual/settings/randomisation_settings.py
+++ b/ev3sim/visual/settings/randomisation_settings.py
@@ -1,0 +1,115 @@
+from ev3sim.visual.settings.elements import NumberEntry, Title
+
+randomisation_settings = [
+    {
+        "height": (lambda s: 290 if s[0] < 580 else 190),
+        "objects": [
+            Title("Colour Sensor", (lambda s: (0, 20))),
+            NumberEntry(["randomisation", "COLOUR_SENSOR_RADIUS"], 1, "Sampling Radius", (lambda s: (0, 70)), float),
+            NumberEntry(
+                ["randomisation", "COLOUR_SENSOR_SAMPLING_POINTS"],
+                100,
+                "Sampling Points",
+                (lambda s: (0, 120) if s[0] < 540 else (s[0] / 2, 70)),
+                int,
+            ),
+            NumberEntry(
+                ["randomisation", "COLOUR_MAX_RGB_BIAS"],
+                400,
+                "Max RGB Bias",
+                (lambda s: (0, 170) if s[0] < 540 else (0, 120)),
+                float,
+            ),
+            NumberEntry(
+                ["randomisation", "COLOUR_MIN_RGB_BIAS"],
+                230,
+                "Min RGB Bias",
+                (lambda s: (0, 220) if s[0] < 540 else (s[0] / 2, 120)),
+                float,
+            ),
+        ],
+    },
+    {
+        "height": (lambda s: 340 if s[0] < 580 else 240),
+        "objects": [
+            Title("Compass Sensor", (lambda s: (0, 20))),
+            NumberEntry(["randomisation", "COMPASS_N_POINTS"], 51, "Static Points", (lambda s: (0, 70)), int),
+            NumberEntry(
+                ["randomisation", "COMPASS_POINT_VARIANCE"],
+                16,
+                "Static Variance",
+                (lambda s: (0, 120) if s[0] < 540 else (s[0] / 2, 70)),
+                float,
+            ),
+            NumberEntry(
+                ["randomisation", "COMPASS_NOISE_RATE"],
+                0.03,
+                "Noise rate of change",
+                (lambda s: (0, 170) if s[0] < 540 else (0, 120)),
+                float,
+            ),
+            NumberEntry(
+                ["randomisation", "COMPASS_NOISE_AMP"],
+                0.2,
+                "Noise amplitude",
+                (lambda s: (0, 220) if s[0] < 540 else (s[0] / 2, 120)),
+                float,
+            ),
+            NumberEntry(
+                ["randomisation", "COMPASS_MAXIMUM_NOISE_EFFECT"],
+                15,
+                "Max Noise effect",
+                (lambda s: (0, 270) if s[0] < 540 else (0, 170)),
+                float,
+            ),
+        ],
+    },
+    {
+        "height": (lambda s: 140),
+        "objects": [
+            Title("Infrared Sensor", (lambda s: (0, 20))),
+            NumberEntry(["randomisation", "INFRARED_BIAS_AMP"], 5, "Bias Amplitude", (lambda s: (0, 70)), float),
+        ],
+    },
+    {
+        "height": (lambda s: 190 if s[0] < 580 else 140),
+        "objects": [
+            Title("Ultrasonic Sensor", (lambda s: (0, 20))),
+            NumberEntry(
+                ["randomisation", "ULTRASONIC_NOISE_ANGLE_AMPLITUDE"],
+                40,
+                "Angle change effect",
+                (lambda s: (0, 70)),
+                float,
+            ),
+            NumberEntry(
+                ["randomisation", "ULTRASONIC_OFFSET_AMP"],
+                5,
+                "Static noise",
+                (lambda s: (0, 120) if s[0] < 540 else (s[0] / 2, 70)),
+                float,
+            ),
+        ],
+    },
+    {
+        "height": (lambda s: 240 if s[0] < 580 else 190),
+        "objects": [
+            Title("Motors", (lambda s: (0, 20))),
+            NumberEntry(["randomisation", "MOTOR_MIN_MULT"], 0.9, "Min speed mult", (lambda s: (0, 70)), float),
+            NumberEntry(
+                ["randomisation", "MOTOR_MAX_MULT"],
+                1.05,
+                "Max speed mult",
+                (lambda s: (0, 120) if s[0] < 540 else (s[0] / 2, 70)),
+                float,
+            ),
+            NumberEntry(
+                ["randomisation", "MOTOR_N_SPEEDS"],
+                71,
+                "Static Points",
+                (lambda s: (0, 170) if s[0] < 540 else (0, 120)),
+                int,
+            ),
+        ],
+    },
+]


### PR DESCRIPTION
Adds a new settings page to ev3sim, allowing you to customise your randomisation settings.
Also allows you to disable / enable these settings.

This should also make it easier for us to fine tune these results (For example it seems the motor mults at the moment are very wild - the bot can go quite off track).

![image](https://user-images.githubusercontent.com/37640160/114114449-3a3ed200-9924-11eb-9b4c-1cf256b98775.png)
![image](https://user-images.githubusercontent.com/37640160/114114470-4034b300-9924-11eb-82d9-664d5bee1c70.png)
