### PR TITLE
Add support for debugging robots

### DIFF
--- a/ev3sim/file_helper.py
+++ b/ev3sim/file_helper.py
@@ -80,3 +80,18 @@ def find_abs_directory(dirpath, create=True):
             fpath = os.path.join(dirname, single)
             os.mkdir(fpath)
             return fpath
+
+
+def ensure_workspace_filled(ws_path):
+    # If the workspace changes, then we should create the necessary folders
+    if not os.path.exists(ws_path):
+        return
+    for dirname in ["custom", "robots", ".vscode"]:
+        if not os.path.exists(os.path.join(ws_path, dirname)):
+            os.mkdir(os.path.join(ws_path, dirname))
+    # Additionally, add a launch.json to .vscode.
+    launch_path = os.path.join(ws_path, ".vscode", "launch.json")
+    if not os.path.exists(launch_path):
+        with open(os.path.join(find_abs("default_launch.json", ["package/presets/"])), "r") as fr:
+            with open(launch_path, "w") as fw:
+                fw.write(fr.read())

--- a/ev3sim/gui.py
+++ b/ev3sim/gui.py
@@ -273,6 +273,7 @@ def main(passed_args=None):
     if not args.no_debug:
         try:
             import debugpy
+
             debugpy.listen(15995)
         except RuntimeError as e:
             print("Warning: Couldn't start the debugger")

--- a/ev3sim/gui.py
+++ b/ev3sim/gui.py
@@ -75,6 +75,12 @@ parser.add_argument(
     help="Downloads and installs a custom task",
     dest="custom_url",
 )
+parser.add_argument(
+    "--no-debug",
+    action="store_true",
+    help="Disable the debug interface",
+    dest="no_debug",
+)
 
 
 def main(passed_args=None):
@@ -263,6 +269,13 @@ def main(passed_args=None):
 
     actual_error = None
     error = None
+
+    if not args.no_debug:
+        try:
+            import debugpy
+            debugpy.listen(15995)
+        except RuntimeError as e:
+            print("Warning: Couldn't start the debugger")
 
     try:
         StateHandler.instance.mainLoop()

--- a/ev3sim/presets/default_launch.json
+++ b/ev3sim/presets/default_launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Python: Attach to EV3Sim",
+        "type": "python",
+        "request": "attach",
+        "connect": {
+          "host": "localhost",
+          "port": 15995
+        }
+      }
+    ]
+  }

--- a/ev3sim/simulation/loader.py
+++ b/ev3sim/simulation/loader.py
@@ -13,7 +13,7 @@ from ev3sim.visual.objects import visualFactory
 import ev3sim.visual.utils
 from ev3sim.constants import *
 from ev3sim.search_locations import bot_locations
-from ev3sim.file_helper import find_abs, find_abs_directory
+from ev3sim.file_helper import ensure_workspace_filled, find_abs, find_abs_directory
 from multiprocessing import Process
 
 
@@ -304,6 +304,12 @@ class ScriptLoader:
             ScreenObjectManager.instance.screens[ScreenObjectManager.instance.SCREEN_SIM].regenerateObjects()
 
 
+class WorkspaceSetting(ObjectSetting):
+    def on_change(self, new_value):
+        super().on_change(new_value)
+        ensure_workspace_filled(new_value)
+
+
 class StateHandler:
     """
     Handles the current sim state, and passes information to the simulator, or other menus where appropriate.
@@ -329,7 +335,7 @@ class StateHandler:
             "tick_rate": ObjectSetting(ScriptLoader, "GAME_TICK_RATE"),
             "timescale": ObjectSetting(ScriptLoader, "TIME_SCALE"),
             "console_log": ObjectSetting(Logger, "LOG_CONSOLE"),
-            "workspace_folder": ObjectSetting(StateHandler, "WORKSPACE_FOLDER"),
+            "workspace_folder": WorkspaceSetting(StateHandler, "WORKSPACE_FOLDER"),
         }
         settings.addSettingGroup("app", loader_settings)
         settings.addSettingGroup("screen", screen_settings)

--- a/ev3sim/updates.py
+++ b/ev3sim/updates.py
@@ -1,6 +1,6 @@
 """Various functions for updating the workspace from earlier versions of ev3sim."""
 
-from ev3sim.file_helper import find_abs
+from ev3sim.file_helper import ensure_workspace_filled, find_abs, find_abs_directory
 
 
 def check_for_bot_files():
@@ -86,8 +86,15 @@ def check_for_bot_files():
     return None
 
 
+def fill_workspace():
+    """Always ensure workspace has the necessary folders."""
+    ensure_workspace_filled(find_abs_directory("workspace"))
+    return None
+
+
 UPDATE_CHECKS = [
     check_for_bot_files,
+    fill_workspace,
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ luddite>=1.0.1
 pygame-gui>=0.5.7
 sentry-sdk>=0.20.0
 dload>=0.6
+debugpy>=1.2.1


### PR DESCRIPTION
This adds support for debugging robots in VS Code. The debugger is automatically launched on port `15995`. To use it just add this to `.vscode/launch.json` 

```
{
  "version": "0.2.0",
  "configurations": [
    {
      "name": "Python: Attach to EV3Sim",
      "type": "python",
      "request": "attach",
      "connect": {
        "host": "localhost",
        "port": 15995
      }
    }
  ]
}
```

There's also a new flag `--no-debug` to disable launching the debugger as it can potentially be exploited by a malicious bot. A possible enhancement could be to create `launch.json` automatically if it doesn't exist, but I'm not sure where to do that.