### PR TITLE
Ensure workspace check is made before attempting to fill it.

### DIFF
--- a/ev3sim/updates.py
+++ b/ev3sim/updates.py
@@ -120,7 +120,10 @@ def check_for_sentry_preference():
 
 def fill_workspace():
     """Always ensure workspace has the necessary folders."""
-    ensure_workspace_filled(find_abs_directory("workspace"))
+    from ev3sim.simulation.loader import StateHandler
+
+    if StateHandler.WORKSPACE_FOLDER:
+        ensure_workspace_filled(find_abs_directory("workspace"))
     return None
 
 


### PR DESCRIPTION
Silly bug introduced in 2.1.7 which would mean ev3sim auto crashes on install if you are not upgrading from a previous version 🤦 