### PR TITLE
Fix windows CI error

### DIFF
--- a/.github/workflows/windows_package_create.yml
+++ b/.github/workflows/windows_package_create.yml
@@ -1,5 +1,9 @@
 name: Windows Executable Creation
 
+on:
+  push:
+    branches-ignore: gh-pages
+
 jobs:
   create-exe:
 
@@ -12,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Disable for now as it hasn't been updated to the new Windows packaging and is causing errors