### PR TITLE
Freeze requirements versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 # We need 1.19.3 for some windows installations.
 # https://github.com/numpy/numpy/wiki/FMod-Bug-on-Windows
 numpy==1.19.3
-pygame>=2.0.1
-PyYAML>=5.3.1
-pymunk>=6.0.0
-python-ev3dev2>=2.1.0.post1
-opensimplex>=0.3
-pygame-gui>=0.5.7
-sentry-sdk>=0.20.0
-debugpy>=1.2.1
-python-certifi-win32>=1.6
-mindpile>=0.0.2
-requests>=2.25.1
+pygame==2.0.1
+PyYAML==5.3.1
+pymunk==6.0.0
+python-ev3dev2==2.1.0.post1
+opensimplex==0.3
+pygame-gui==0.5.7
+sentry-sdk==0.20.0
+debugpy==1.2.1
+python-certifi-win32==1.6
+mindpile==0.0.2
+requests==2.25.1


### PR DESCRIPTION
Set static versions of dependencies to allow for better reproducibility. Maybe we can look into tools like poetry or pipenv later for even more consistency. This will be required for the Nix build PR #289 . 