### PR TITLE
 Add platform folders support to search paths 

### DIFF
--- a/ev3sim/search_locations.py
+++ b/ev3sim/search_locations.py
@@ -1,23 +1,9 @@
 preset_locations = lambda: ["workspace/presets/", "workspace", "package/presets/"]
+config_locations = lambda: ["workspace", "platform/config", "package"]
 device_locations = lambda: ["workspace/devices/", "package/devices/"]
 theme_locations = lambda: ["workspace/assets/", "workspace", "package/assets"]
 asset_locations = lambda: ["workspace/assets/", "workspace", "package/assets/"]
-
-
-def config_locations():
-    import os
-    import platform
-    from pathlib import Path
-
-    if platform.system() == "Linux":
-        home_dir = os.path.expanduser("~")
-        xdg_config_dir = os.environ.get("XDG_CONFIG_HOME") or os.path.join(home_dir, ".config")
-        config_dir = os.path.join(xdg_config_dir, "ev3sim")
-        # Ensure config dir exists
-        Path(config_dir).mkdir(parents=True, exist_ok=True)
-        return ["workspace", "local|" + config_dir]
-
-    return ["workspace", "package"]
+workspace_locations = lambda: ["platform/data/workspace/", "package/workspace/"]
 
 
 def code_locations(bot_path):

--- a/flake.lock
+++ b/flake.lock
@@ -40,16 +40,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1622516815,
-        "narHash": "sha256-ZjBd81a6J3TwtlBr3rHsZspYUwT9OdhDk+a/SgSEf7I=",
+        "lastModified": 1628696641,
+        "narHash": "sha256-4Qb0Rpx8kjnPxNJiw15CmmV9hfiyvzlUzGcOn8bXKXQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7e9b0dff974c89e070da1ad85713ff3c20b0ca97",
+        "rev": "10bb036486138341e4c760c4c98ddadef56fff7b",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "21.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -58,24 +58,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "mindpile": "mindpile",
-        "nixpkgs": "nixpkgs",
-        "unstable": "unstable"
-      }
-    },
-    "unstable": {
-      "locked": {
-        "lastModified": 1627148163,
-        "narHash": "sha256-3FXDUlHtdRW9ajQ4NqcfZHx6IYnxQluhB+06pxE4m1k=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "9aec01027f7ea2bca07bb51d5ed83e78088871c1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,24 +1,22 @@
 {
-  description = "A simulator for soccer robots programmed with ev3dev.";
+  description = "A simulator for soccer robots programmed with ev3dev";
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/21.05";
   # On unstable to use some new python packages. Eventually will be merged into Nix 21.11
-  inputs.unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.mindpile.url = "github:MelbourneHighSchoolRobotics/mindpile";
   inputs.mindpile.inputs.nixpkgs.follows = "nixpkgs";
   inputs.mindpile.inputs.flake-utils.follows = "flake-utils";
 
-  outputs = { nixpkgs, unstable, flake-utils, mindpile, ... }:
+  outputs = { nixpkgs, flake-utils, mindpile, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        unstablePkgs = unstable.legacyPackages.${system};
+        mp = mindpile.legacyPackages.${system};
       in rec {
         packages = {
           linux = pkgs.callPackage ./nix/linux.nix {
-            inherit (unstablePkgs.python39Packages) ev3dev2 opensimplex pymunk pygame pygame-gui;
-            mindpile = mindpile.legacyPackages.${system}.mindpile;
+            inherit (mp) mindpile;
           };
 
           windows = pkgs.callPackage ./nix/windows-installer.nix { };

--- a/nix/linux.nix
+++ b/nix/linux.nix
@@ -1,4 +1,4 @@
-{ pkgs, pymunk, ev3dev2, opensimplex, pygame, pygame-gui, mindpile, ... }:
+{ pkgs, mindpile, ... }:
 pkgs.python39Packages.buildPythonPackage
 (let version = pkgs.callPackage ./version.nix { };
 in {


### PR DESCRIPTION
Moved data to platform native locations with the `platform` placeholder. Only linux supports these locations for now, and this is a no-op on windows and mac. This gets the linux packaged version all the way up to the main menu. Next thing to tackle is the soccer/rescue preset sim files needing to be writeable.